### PR TITLE
chore: update SurveyCalculator for .NET 8 and AutoCAD 2025

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- Change to your actual install path if needed -->
-    <ACAD_DIR>C:\Program Files\Autodesk\AutoCAD Map 3D 2025</ACAD_DIR>
+    <!-- Update if your path differs -->
+    <ACAD_DIR>C:\Program Files\Autodesk\AutoCAD 2025</ACAD_DIR>
   </PropertyGroup>
 </Project>
+

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # SurveyCalculator
 
-AutoCAD Map 3D plugin seed (.NET Framework 4.8, x64).
+AutoCAD Map 3D plugin seed (.NET 8, x64).
 
 ## Build requirements
 - Windows + Visual Studio 2022
-- .NET Framework 4.8 targeting pack
-- AutoCAD Map 3D (managed DLL references)
+- .NET 8 (net8.0-windows)
+- AutoCAD 2025 (managed DLL references; Map API lives under the `\Map` subfolder)
 
-Set your Map 3D install path in **Directory.Build.props**:
+Set your AutoCAD install path in **Directory.Build.props**:
 ```xml
-<ACAD_DIR>C:\Program Files\Autodesk\AutoCAD Map 3D 2025</ACAD_DIR>
+<ACAD_DIR>C:\Program Files\Autodesk\AutoCAD 2025</ACAD_DIR>
 ```
 
 ## Build
 Open src/SurveyCalculator/SurveyCalculator.csproj in VS and build Release | x64, or:
 
 ```css
-msbuild .\src\SurveyCalculator\SurveyCalculator.csproj /p:Configuration=Release
+msbuild .\src\SurveyCalculator\SurveyCalculator.csproj /p:Configuration=Release /p:Platform=x64
 ```
 
 The DLL is copied to /deploy on post-build.

--- a/src/SurveyCalculator/SurveyCalculator.csproj
+++ b/src/SurveyCalculator/SurveyCalculator.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
+    <UseWindowsForms>true</UseWindowsForms>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>SurveyCalculator</RootNamespace>
     <AssemblyName>SurveyCalculator</AssemblyName>
@@ -20,15 +21,20 @@
       <HintPath>$(ACAD_DIR)\acmgd.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="ManagedMapApi">
-      <HintPath>$(ACAD_DIR)\ManagedMapApi.dll</HintPath>
+    <!-- Editor/Prompt* APIs live here -->
+    <Reference Include="AcCoreMgd">
+      <HintPath>$(ACAD_DIR)\AcCoreMgd.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <!-- Map vertical (present under \Map) -->
+    <Reference Include="ManagedMapApi" Condition="Exists('$(ACAD_DIR)\Map\ManagedMapApi.dll')">
+      <HintPath>$(ACAD_DIR)\Map\ManagedMapApi.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- target net8.0-windows and enable WinForms for x64
- reference AutoCAD 2025 assemblies including AcCoreMgd and Map API
- replace JavaScriptSerializer with System.Text.Json and alias AutoCAD Application
- replace index-from-end operators with explicit indexing

## Testing
- `msbuild ./src/SurveyCalculator/SurveyCalculator.csproj /p:Configuration=Release /p:Platform=x64` *(fails: command not found)*
- `dotnet build src/SurveyCalculator/SurveyCalculator.csproj -c Release -p:Platform=x64` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899ec253ebc832294b786f34690b777