### PR TITLE
Add COGO CSV save/load and target .NET Framework 4.8

### DIFF
--- a/src/SurveyCalculator/SurveyCalculator.csproj
+++ b/src/SurveyCalculator/SurveyCalculator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <PlatformTarget>x64</PlatformTarget>
@@ -32,6 +32,10 @@
       <HintPath>$(ACAD_DIR)\Map\ManagedMapApi.dll</HintPath>
       <Private>false</Private>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
   <!-- Copy the built DLL to /deploy for easy NETLOAD -->


### PR DESCRIPTION
## Summary
- Persist user-entered COGO data to a `COGO.csv` file and reload it on wizard startup
- Export COGO entries from command workflows for reuse across drawings
- Retarget project to .NET Framework 4.8 and add System.Text.Json package

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5a1a08a08322ab2ac481aa850e54