### PR TITLE
Ensure .NET Framework 4.8 compatibility and COGO persistence

### DIFF
--- a/src/SurveyCalculator/SurveyCalculator.csproj
+++ b/src/SurveyCalculator/SurveyCalculator.csproj
@@ -1,41 +1,49 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <PlatformTarget>x64</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
     <RootNamespace>SurveyCalculator</RootNamespace>
     <AssemblyName>SurveyCalculator</AssemblyName>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <Nullable>disable</Nullable>
     <Deterministic>true</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <!-- Autodesk managed assemblies -->
   <ItemGroup>
     <Reference Include="acdbmgd">
-      <HintPath>$(ACAD_DIR)\acdbmgd.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\AutoCAD Map 3D 2015\acdbmgd.dll</HintPath>
       <Private>false</Private>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="acmgd">
-      <HintPath>$(ACAD_DIR)\acmgd.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\AutoCAD Map 3D 2015\acmgd.dll</HintPath>
       <Private>false</Private>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
-    <!-- Editor/Prompt* APIs live here -->
-    <Reference Include="AcCoreMgd">
-      <HintPath>$(ACAD_DIR)\AcCoreMgd.dll</HintPath>
+    <Reference Include="accoremgd">
+      <HintPath>C:\Program Files\Autodesk\AutoCAD Map 3D 2015\accoremgd.dll</HintPath>
       <Private>false</Private>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
-    <!-- Map vertical lives under the \Map subfolder -->
-    <Reference Include="ManagedMapApi" Condition="Exists('$(ACAD_DIR)\Map\ManagedMapApi.dll')">
-      <HintPath>$(ACAD_DIR)\Map\ManagedMapApi.dll</HintPath>
+    <Reference Include="ManagedMapApi">
+      <HintPath>C:\Program Files\Autodesk\AutoCAD Map 3D 2015\ManagedMapApi.dll</HintPath>
       <Private>false</Private>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
-  </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Web.Extensions" />
   </ItemGroup>
 
   <!-- Copy the built DLL to /deploy for easy NETLOAD -->


### PR DESCRIPTION
## Summary
- Target classic .NET Framework 4.8 with C# 7.3 and x64, referencing AutoCAD Map 3D framework assemblies and removing conflicting packages
- Replace C# 8+ features (index-from-end, TrimEntries, using declarations) and switch JSON helper to JavaScriptSerializer for framework compatibility
- Save/load COGO data from sidecar `COGO` file, falling back to `COGO.csv` and preserving raw distances in manual PLANCOGO

## Testing
- `dotnet build src/SurveyCalculator/SurveyCalculator.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f5f7124bc8322855e950a2f3f6258